### PR TITLE
Improve data model

### DIFF
--- a/export/prometheus_push.lua
+++ b/export/prometheus_push.lua
@@ -16,38 +16,28 @@ local export_size = monitoring.counter(
 	"byte count of the prometheus export"
 )
 
-function monitoring.serialize_prometheus_labels(labels)
-	local str = ""
-	local i = 0
-	for k,v in pairs(labels or {}) do
-		if v ~= nil then
-			str = str .. k .. "=\"" .. v .. "\","
-			i = i + 1
-		end
+function monitoring.serialize_prometheus_metric_family(metric_family)
+	local data = ""
+
+	data = data .. "# TYPE " .. metric_family.name .. " " .. metric_family.type .. "\n"
+	data = data .. "# HELP " .. metric_family.name .. " " .. metric_family.help .. "\n"
+	if metric_family.unit then
+		data = data .. "# UNIT " .. metric_family.name .. " " .. metric_family.unit .. "\n"
 	end
 
-	if i > 0 then
-		return "{" .. string.sub(str, 1, #str-1) .. "}"
-	else
-		return ""
+	for serialized_labels, metric in pairs(metric_family.metrics) do
+		data = data .. monitoring.serialize_prometheus_metric(serialized_labels, metric)
 	end
+
+	return data
 end
 
-function monitoring.serialize_prometheus_metric(metric)
+function monitoring.serialize_prometheus_metric(serialized_labels, metric)
 	local data = ""
 	if metric.value or metric.value == 0 then
-		data = data .. "# TYPE " .. metric.name .. " " .. metric.type .. "\n"
-		data = data .. "# HELP " .. metric.name .. " " .. metric.help .. "\n"
-
 		if metric.value ~= nil then
 		if metric.type == "gauge" or metric.type == "counter" then
-			data = data .. metric.name
-			if metric.options and metric.options.labels then
-				-- append labels
-				data = data .. monitoring.serialize_prometheus_labels(metric.options.labels)
-			end
-			data = data  .. " " .. metric.value .. "\n"
-
+			data = data .. metric.name .. serialized_labels .. " " .. metric.value .. "\n"
 			if metric.options and metric.options.autoflush then
 				-- reset metric value on export
 				metric.value = nil
@@ -57,11 +47,11 @@ function monitoring.serialize_prometheus_metric(metric)
 
 		if metric.type == "histogram" then
 			for k, bucket in ipairs(metric.buckets) do
-				data = data .. metric.name .. "_bucket{le=\"" .. bucket  .. "\"} " .. metric.bucketvalues[k] .. "\n"
+				data = data .. metric.name .. "_bucket{le=\"" .. bucket  .. "\"}".. serialized_labels .. " " .. metric.bucketvalues[k] .. "\n"
 			end
-			data = data .. metric.name .. "_bucket{le=\"+Inf\"} " .. metric.infcount .. "\n"
-			data = data .. metric.name .. "_sum " .. metric.sum .. "\n"
-			data = data .. metric.name .. "_count " .. metric.count .. "\n"
+			data = data .. metric.name .. "_bucket{le=\"+Inf\"}".. serialized_labels .. " " .. metric.infcount .. "\n"
+			data = data .. metric.name .. "_sum".. serialized_labels .. " " .. metric.sum .. "\n"
+			data = data .. metric.name .. "_count".. serialized_labels .. " " .. metric.count .. "\n"
 		end
 	end
 	return data
@@ -71,8 +61,8 @@ local function push_metrics()
 	local t0 = minetest.get_us_time()
 
 	local data = ""
-	for _, metric in ipairs(monitoring.metrics) do
-		data = data .. monitoring.serialize_prometheus_metric(metric)
+	for _, metric_family in ipairs(monitoring.metrics) do
+		data = data .. monitoring.serialize_prometheus_metric_family(metric_family)
 	end
 
 	local t_collect_us = get_us_time() - t0

--- a/export/prometheus_push.lua
+++ b/export/prometheus_push.lua
@@ -61,7 +61,7 @@ local function push_metrics()
 	local t0 = minetest.get_us_time()
 
 	local data = ""
-	for _, metric_family in ipairs(monitoring.metrics) do
+	for _, metric_family in pairs(monitoring.metrics) do
 		data = data .. monitoring.serialize_prometheus_metric_family(metric_family)
 	end
 
@@ -93,6 +93,8 @@ function monitoring.prometheus_push_init()
 		timer = timer + dtime
 		if timer < 5 then return end
 		timer=0
+
+		core.debug("[monitoring] pushing metrics to prometheus push gateway")
 
 		push_metrics()
 	end)

--- a/export/prometheus_push.spec.lua
+++ b/export/prometheus_push.spec.lua
@@ -1,57 +1,76 @@
 
-mtt.register("serialize_prometheus_metric", function(callback)
+mtt.register("serialize_prometheus_metric_family", function(callback)
     local m = monitoring.gauge("my_metric", "help stuff")
     assert(monitoring.metrics_mapped["my_metric"] == m)
 
-    local str = monitoring.serialize_prometheus_metric(m)
+    local str = monitoring.serialize_prometheus_metric("{}", m)
     assert(str == "")
 
     m.set(1)
-    str = monitoring.serialize_prometheus_metric(m)
+    str = monitoring.serialize_prometheus_metric("{}", m)
 
     local lines = {}
     for s in str:gmatch("[^\n]+") do
         table.insert(lines, s)
     end
 
-    assert(#lines == 3)
-    assert(lines[1] == "# TYPE my_metric gauge")
-    assert(lines[2] == "# HELP my_metric help stuff")
-    assert(lines[3] == "my_metric 1")
+    assert(#lines == 1)
+    assert(lines[1] == "my_metric{} 1")
 
-    m = monitoring.gauge("my_metric", "help stuff", {
+    local m2 = monitoring.gauge("my_metric", "help stuff", {
         labels = { x = "123" }
     })
     assert(monitoring.metrics_mapped["my_metric"] == m)
     m.set(1)
 
-    str = monitoring.serialize_prometheus_metric(m)
+    str = monitoring.serialize_prometheus_metric("{x=\"123\"}", m)
 
     lines = {}
     for s in str:gmatch("[^\n]+") do
         table.insert(lines, s)
     end
 
-    assert(#lines == 3)
-    assert(lines[1] == "# TYPE my_metric gauge")
-    assert(lines[2] == "# HELP my_metric help stuff")
-    assert(lines[3] == "my_metric{x=\"123\"} 1")
+    assert(#lines == 1)
+    assert(lines[1] == "my_metric{x=\"123\"} 1")
 
     callback()
 end)
 
-mtt.register("serialize_prometheus_labels", function(callback)
-    local str = monitoring.serialize_prometheus_labels(nil)
+
+
+mtt.register("serialize_prometheus_metric", function(callback)
+    local m = monitoring.gauge("my_metric2", "help stuff")
+    assert(monitoring.metrics_mapped["my_metric2"] == m)
+
+    local str = monitoring.serialize_prometheus_metric("{}", m)
     assert(str == "")
 
-    str = monitoring.serialize_prometheus_labels({})
-    assert(str == "")
+    m.set(1)
+    str = monitoring.serialize_prometheus_metric("{}", m)
 
-    str = monitoring.serialize_prometheus_labels({x="abc"})
-    assert(str == "{x=\"abc\"}")
+    local lines = {}
+    for s in str:gmatch("[^\n]+") do
+        table.insert(lines, s)
+    end
 
-    str = monitoring.serialize_prometheus_labels({x="abc", y="123"})
-    assert(str == "{x=\"abc\",y=\"123\"}" or str == "{y=\"123\",x=\"abc\"}")
+    assert(#lines == 1)
+    assert(lines[1] == "my_metric2{} 1")
+
+    local m2 = monitoring.gauge("my_metric2", "help stuff", {
+        labels = { x = "123" }
+    })
+    assert(monitoring.metrics_mapped["my_metric2"] == m)
+    m2.set(1)
+
+    str = monitoring.serialize_prometheus_metric("{x=\"123\"}", m2)
+
+    lines = {}
+    for s in str:gmatch("[^\n]+") do
+        table.insert(lines, s)
+    end
+
+    assert(#lines == 1)
+    assert(lines[1] == "my_metric2{x=\"123\"} 1")
 
     callback()
 end)

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ monitoring = {
 local http = minetest.get_modpath("qos") and QoS and QoS(minetest.request_http_api(), 2) or minetest.request_http_api()
 local MP = minetest.get_modpath("monitoring")
 
+dofile(MP.."/metrictypes/core.lua")
 dofile(MP.."/metrictypes/gauge.lua")
 dofile(MP.."/metrictypes/counter.lua")
 dofile(MP.."/metrictypes/histogram.lua")
@@ -146,6 +147,7 @@ end
 if minetest.get_modpath("mtt") and mtt.enabled then
   -- test utils
   dofile(MP.."/init.spec.lua")
+  dofile(MP.."/metrictypes/core.spec.lua")
   dofile(MP.."/metrictypes/counter.spec.lua")
   dofile(MP.."/export/prometheus_push.spec.lua")
 end

--- a/metrictypes/core.lua
+++ b/metrictypes/core.lua
@@ -13,8 +13,9 @@ function monitoring.serialize_labels(labels)
 
     for _, k in ipairs(label_names) do
         local v = labels[k]
-        if v ~= nil and #v > 0 then
-            str = str .. k .. "=\"" .. v .. "\","
+        local vstr = v and tostring(v) or ""
+        if v ~= nil and #vstr > 0 then
+            str = str .. k .. "=\"" .. vstr .. "\","
         end
     end
 

--- a/metrictypes/core.lua
+++ b/metrictypes/core.lua
@@ -1,0 +1,68 @@
+function monitoring.serialize_labels(labels)
+	
+    if not labels or type(labels) ~= "table" then
+        return ""
+    end
+    
+    local str = ""
+	local i = 0
+
+    local label_names = {}
+    for k, _ in pairs(labels) do table.insert(label_names, k) end
+    table.sort(label_names)    
+
+    for _, k in ipairs(label_names) do
+        local v = labels[k]
+        if v ~= nil and #v > 0 then
+            str = str .. k .. "=\"" .. v .. "\","
+        end
+    end
+
+	if #str > 0 then
+		return "{" .. string.sub(str, 1, #str-1) .. "}"
+	else
+		return ""
+	end
+end
+
+
+ function monitoring.register_metric(metric)
+
+    local metric_family = monitoring.metrics[metric.name]
+
+    if metric_family then
+        -- Metric already exists, check 
+        if metric_family.type ~= metric.type then
+            error("Metric type mismatch for " .. metric.name .. ": " .. metric_family.type .. " vs " .. metric.type)
+        end
+        if metric_family.help ~= metric.help then
+            error("Metric help mismatch for " .. metric.name .. ": " .. metric_family.help .. " vs " .. metric.help)
+        end
+    else
+        metric_family = {
+            name = metric.name,
+            help = metric.help,
+            type = metric.type,
+            unit = metric.options and metric.options.unit or nil,
+            metrics = {}
+        }
+        -- Create a new metric family
+        monitoring.metrics[metric.name] = metric_family
+    end
+
+    local labels = metric.labels or {}
+    local labels_str = monitoring.serialize_labels(labels)
+
+    local res_metric = metric_family.metrics[labels_str]
+    if not res_metric then
+        res_metric =  metric
+        metric_family.metrics[labels_str] = metric
+    end
+
+    if not monitoring.metrics_mapped[metric.name] then
+        monitoring.metrics_mapped[metric.name] = res_metric
+    end
+
+    return res_metric
+
+end

--- a/metrictypes/core.spec.lua
+++ b/metrictypes/core.spec.lua
@@ -1,0 +1,15 @@
+mtt.register("serialize_labels", function(callback)
+    local str = monitoring.serialize_labels(nil)
+    assert(str == "")
+
+    str = monitoring.serialize_labels({})
+    assert(str == "")
+
+    str = monitoring.serialize_labels({x="abc"})
+    assert(str == "{x=\"abc\"}")
+
+    str = monitoring.serialize_labels({x="abc", y="123"})
+    assert(str == "{x=\"abc\",y=\"123\"}")
+
+    callback()
+end)

--- a/metrictypes/counter.lua
+++ b/metrictypes/counter.lua
@@ -7,6 +7,7 @@ monitoring.counter = function(name, help, options)
 		name = name,
 		help = help,
 		type = "counter",
+		labels = options and options.labels or {},
 		value = 0,
 		options = options or {}
 	}
@@ -52,8 +53,6 @@ monitoring.counter = function(name, help, options)
 		end
 	end
 
-	table.insert(monitoring.metrics, metric)
-	monitoring.metrics_mapped[name] = metric
+	return monitoring.register_metric(metric)
 
-	return metric
 end

--- a/metrictypes/gauge.lua
+++ b/metrictypes/gauge.lua
@@ -4,6 +4,7 @@ monitoring.gauge = function(name, help, options)
 		name = name,
 		help = help,
 		type = "gauge",
+		labels = options and options.labels or {},
 		options = options or {}
 	}
 
@@ -35,8 +36,5 @@ monitoring.gauge = function(name, help, options)
 		end
 	end
 
-	table.insert(monitoring.metrics, metric)
-	monitoring.metrics_mapped[name] = metric
-
-	return metric
+	return monitoring.register_metric(metric)
 end

--- a/metrictypes/histogram.lua
+++ b/metrictypes/histogram.lua
@@ -1,8 +1,8 @@
 
 local get_us_time = minetest.get_us_time
 
-monitoring.histogram = function(name, help, buckets)
-	buckets = buckets or {0.01, 0.05, 0.1, 0.2, 0.5, 1.0}
+monitoring.histogram = function(name, help, options)
+	local buckets = (options and options.buckets) or {0.01, 0.05, 0.1, 0.2, 0.5, 1.0}
 	local bucketvalues = {}
 	for k in ipairs(buckets) do
 		bucketvalues[k] = 0
@@ -12,6 +12,7 @@ monitoring.histogram = function(name, help, buckets)
 		name = name,
 		help = help,
 		type = "histogram",
+		labels = options and options.labels or {},
 		buckets = buckets,
 		bucketvalues = bucketvalues,
 		sum = 0,
@@ -19,8 +20,7 @@ monitoring.histogram = function(name, help, buckets)
 		infcount = 0
 	}
 
-	table.insert(monitoring.metrics, metric)
-	monitoring.metrics_mapped[name] = metric
+	metric = monitoring.register_metric(metric)
 
 	-- adds the value to the buckets
 	local add_value = function(seconds)


### PR DESCRIPTION
### Problem

In the current implementation, it is not possible to define metrics with the same name but different label sets. This limitation leads to `400` errors from Prometheus.

The root cause is the absence of support for *Metric Families*. According to the [[OpenMetrics specification](https://prometheus.io/docs/specs/om/open_metrics_spec/)](https://prometheus.io/docs/specs/om/open_metrics_spec/), which Prometheus adheres to, metrics sharing a name but differing in labels should be grouped under a single Metric Family.

---

### Proposal

This PR introduces an implementation of Metric Families in alignment with the OpenMetrics model.
The goal is to preserve the existing library API and behavior as much as possible, while resolving the incompatibility with Prometheus.

Notable changes include:

* A modification to the `buckets` argument for histogram definitions.
* Adjusted behavior of the `monitoring.metric_mapped` property to support the new model.

These adjustments are designed to be minimally invasive while enabling compliance with Prometheus and OpenMetrics expectations.

---

I’m happy to receive any feedback or suggestions for improvement. Please let me know if anything needs to be clarified or adjusted.